### PR TITLE
Fix URL if WordPress in subfolder

### DIFF
--- a/src/CSS.php
+++ b/src/CSS.php
@@ -177,7 +177,7 @@ class CSS {
 		// Enqueue the dynamic stylesheet.
 		wp_enqueue_style(
 			'kirki-styles',
-			add_query_arg( $args, site_url() ),
+			add_query_arg( $args, home_url() ),
 			[],
 			'4.0'
 		);


### PR DESCRIPTION
In some cases people save WP core in a subfolder such as /wp. Changing this goes sure that the URL is `example.com/?action=kirki-styles` instead of `example.com/wp?action=kirki-styles`. Latter can produce 404s.